### PR TITLE
Support redirection of load-balancer

### DIFF
--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -61,6 +61,12 @@ class AuthenticationState:
 
 class StartAuthentication(AuthenticationState):
     async def trigger(self):
+        logger.debug("Auth started", url=self.authenticator.host.vpn_url)
+        response = requests.get(self.authenticator.host.vpn_url)
+        response.raise_for_status()
+        self.authenticator.host.address = response.url
+        logger.debug("Auth target url", url=self.authenticator.host.vpn_url)
+
         request = _create_auth_init_request(
             self.authenticator.host, self.authenticator.host.vpn_url
         )


### PR DESCRIPTION
In case of a load-balancer, the server returns HTTP 302 with the new
location.

requests supports the redirection however the redirect (HTTP 302) change the
POST to GET.

./openconnect_sso/cli.py -l DEBUG
Using selector: EpollSelector
[info     ] Authenticating to VPN endpoint [openconnect_sso.app] address=vpn-cluster.company.com name=SSL
[debug    ] Entering state                 [openconnect_sso.authenticator] state=<STATE StartAuthentication>
Starting new HTTPS connection (1): vpn-cluster.company.com:443
https://vpn-cluster.company.com:443 "POST /ssl HTTP/1.1" 302 0
Starting new HTTPS connection (1): vpn-cluster-5.company.com:443
https://vpn-cluster-5.company.com:443 "GET /ssl HTTP/1.1" 404 0

Quoting RFC:
"""
Note: RFC 1945 and RFC 2068 specify that the client is not allowed to change the method on the redirected request. However, most existing user agent implementations treat 302 as if it were a 303 response, performing a GET on the Location field-value regardless of the original request method. The status codes 303 and 307 have been added for servers that wish to make unambiguously clear which kind of reaction is expected of the client.
"""

If X-Aggregate-Auth is set header, after the redirect, the server
returns 404. So a HTTP request without specifc headers set to
get the location.