### PR TITLE
Do not use default profile if --server is specified

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -61,7 +61,7 @@ async def _run(args):
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")
         cfg.credentials = credentials
 
-    if cfg.default_profile and not args.use_profile_selector:
+    if cfg.default_profile and not (args.use_profile_selector or args.server):
         selected_profile = cfg.default_profile
     elif args.use_profile_selector or args.profile_path:
         profiles = get_profiles(Path(args.profile_path))


### PR DESCRIPTION
This caused a lot of headaches for me trying to use this as I messed up on my --server/--group the first time around.  But because it saved it as the default profile, it didn't matter that I did --server after that.  Took me a bit to realize what was going on, find the default profile and update it.  Figured this would prevent someone else from having the same issue.