### PR TITLE
Update dependencies

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import structlog
 from prompt_toolkit import HTML
-from prompt_toolkit.eventloop import use_asyncio_event_loop
 from prompt_toolkit.shortcuts import radiolist_dialog
 
 from openconnect_sso import config
@@ -24,8 +23,6 @@ logger = structlog.get_logger()
 
 def run(args):
     configure_logger(logging.getLogger(), args.log_level)
-    loop = asyncio.get_event_loop()
-    use_asyncio_event_loop(loop)
 
     try:
         return asyncio.get_event_loop().run_until_complete(_run(args))
@@ -123,8 +120,7 @@ async def select_profile(profile_list):
             "The selection will be <b>saved</b> and not asked again unless the <pre>--profile-selector</pre> command line option is used"
         ),
         values=[(p, p.name) for i, p in enumerate(profile_list)],
-        async_=True,
-    ).to_asyncio_future()
+    ).run_async()
     asyncio.get_event_loop().remove_signal_handler(signal.SIGWINCH)
     if not selection:
         return selection

--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -167,8 +167,8 @@ class AuthRequestResponse:
     auth_message = attr.ib(converter=str)
     auth_error = attr.ib(converter=str)
     login_url = attr.ib(converter=str)
-    login_final_url = attr.ib(convert=str)
-    token_cookie_name = attr.ib(convert=str)
+    login_final_url = attr.ib(converter=str)
+    token_cookie_name = attr.ib(converter=str)
     opaque = attr.ib()
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -161,7 +161,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8"
+version = "2.9"
 
 [[package]]
 category = "main"
@@ -428,16 +428,16 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.22.0"
+version = "2.23.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<3.1.0"
-idna = ">=2.5,<2.9"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -542,11 +542,11 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "2.2.0"
+version = "3.0.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["jaraco.itertools"]
+testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
 full = ["PyQt5", "PyQtWebEngine"]
@@ -694,8 +694,8 @@ entrypoints = [
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
 idna = [
-    {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
-    {file = "idna-2.8.tar.gz", hash = "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"},
+    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
+    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
@@ -763,10 +763,10 @@ pycparser = [
     {file = "pycparser-2.19.tar.gz", hash = "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"},
 ]
 pyqt5 = [
-    {file = "PyQt5-5.14.1-5.14.0-cp35.cp36.cp37.cp38-abi3-macosx_10_6_intel.whl", hash = "sha256:3d6e315e6e2d6489a2e1e0148d00e784e277c6590c189227d6060f15b9be690a"},
-    {file = "PyQt5-5.14.1-5.14.0-cp35.cp36.cp37.cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:be10fa95e6bdc9cad616ebf368c51b3f5748138b2b3a600cf7c4f80b78cb9852"},
-    {file = "PyQt5-5.14.1-5.14.0-cp35.cp36.cp37.cp38-none-win32.whl", hash = "sha256:812233bd155735377e2e9c7eea7a28815f357440334db51788d941e2a8b62f64"},
-    {file = "PyQt5-5.14.1-5.14.0-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:2b79209aa6e4688f6ac46e6d2694236dcf91db5f3a87270150d0f82082e3d360"},
+    {file = "PyQt5-5.14.1-5.14.1-cp35.cp36.cp37.cp38-abi3-macosx_10_6_intel.whl", hash = "sha256:a0bfe9fd718bca4de3e33000347e048f73126b6dc46530eb020b0251a638ee9d"},
+    {file = "PyQt5-5.14.1-5.14.1-cp35.cp36.cp37.cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:713b9a201f5e7b2fca8691373e5d5c8c2552a51d87ca9ffbb1461e34e3241211"},
+    {file = "PyQt5-5.14.1-5.14.1-cp35.cp36.cp37.cp38-none-win32.whl", hash = "sha256:2d94ec761fb656707050c68b41958e3a9f755bb1df96c064470f4096d2899e32"},
+    {file = "PyQt5-5.14.1-5.14.1-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:31b142a868152d60c6323e0527edb692fdf05fd7cb4fe2fe9ce07d1ce560221a"},
     {file = "PyQt5-5.14.1.tar.gz", hash = "sha256:2f230f2dbd767099de7a0cb915abdf0cbc3256a0b5bb910eb09b99117db7a65b"},
 ]
 pyqt5-sip = [
@@ -789,10 +789,10 @@ pyqt5-sip = [
     {file = "PyQt5_sip-12.7.1.tar.gz", hash = "sha256:e6078f5ee7d31c102910d0c277a110e1c2a20a3fc88cd017a39e170120586d3f"},
 ]
 pyqtwebengine = [
-    {file = "PyQtWebEngine-5.14.0-5.14.0-cp35.cp36.cp37.cp38-abi3-macosx_10_6_intel.whl", hash = "sha256:04a841c773b6c76f1954ae7ebd628776c102be6c7898f01f59a0283f3b75c50a"},
-    {file = "PyQtWebEngine-5.14.0-5.14.0-cp35.cp36.cp37.cp38-abi3-manylinux1_x86_64.whl", hash = "sha256:8d6c057a788fb030dd608a04da1c1d3d004b4422dd712c9b768ee030ca899ab8"},
-    {file = "PyQtWebEngine-5.14.0-5.14.0-cp35.cp36.cp37.cp38-none-win32.whl", hash = "sha256:033eaeb748a8eb70bb9557a650b2344f2b30c99cbd88eaea7e344a136c79423c"},
-    {file = "PyQtWebEngine-5.14.0-5.14.0-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:c206947e4df0c1647116b22bd79f4858b109b6347102681b40c2e09afb898fe7"},
+    {file = "PyQtWebEngine-5.14.0-5.14.1-cp35.cp36.cp37.cp38-abi3-macosx_10_6_intel.whl", hash = "sha256:b19a889e2ba4ea4b6ab8748f01ad47a5bd89dd132e047adbae81bd3c6e60a8f6"},
+    {file = "PyQtWebEngine-5.14.0-5.14.1-cp35.cp36.cp37.cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:73a616b453b0bb174e15bb3de29a7965f71fc701d8f450d29c483cd954654087"},
+    {file = "PyQtWebEngine-5.14.0-5.14.1-cp35.cp36.cp37.cp38-none-win32.whl", hash = "sha256:3c0878558d463e65db97c3e85092281d5d035f7cd326502d6575c7e333e20c5a"},
+    {file = "PyQtWebEngine-5.14.0-5.14.1-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:4c5dd807018d5e826cc9b18d8e626ac33d2d96575f3879ef4287d0554f8dd526"},
     {file = "PyQtWebEngine-5.14.0.tar.gz", hash = "sha256:e11595051f8bfbfa49175d899b2c8c2eea3a3deac4141edf4db68c3555221c92"},
 ]
 pytest = [
@@ -837,8 +837,8 @@ reno = [
     {file = "reno-2.11.3.tar.gz", hash = "sha256:98e1eb504566e17611b2cbdbcc065aa4f35d34d3382aafaadeb041b399ca7544"},
 ]
 requests = [
-    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
-    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
+    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
 ]
 secretstorage = [
     {file = "SecretStorage-3.1.2-py3-none-any.whl", hash = "sha256:b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"},
@@ -879,6 +879,6 @@ werkzeug = [
     {file = "Werkzeug-1.0.0.tar.gz", hash = "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096"},
 ]
 zipp = [
-    {file = "zipp-2.2.0-py36-none-any.whl", hash = "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"},
-    {file = "zipp-2.2.0.tar.gz", hash = "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50"},
+    {file = "zipp-3.0.0-py3-none-any.whl", hash = "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2"},
+    {file = "zipp-3.0.0.tar.gz", hash = "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -263,11 +263,10 @@ category = "main"
 description = "Library for building powerful interactive command lines in Python"
 name = "prompt-toolkit"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.0.10"
+python-versions = ">=3.6"
+version = "3.0.3"
 
 [package.dependencies]
-six = ">=1.9.0"
 wcwidth = "*"
 
 [[package]]
@@ -553,7 +552,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 full = ["PyQt5", "PyQtWebEngine"]
 
 [metadata]
-content-hash = "605912e67827a3043c9c7153fb17848ad86fcfa5c9581ffb03af7fb14ee2513b"
+content-hash = "4665b3755c630c530496c2b98f82dbad930a8c452ee781a7108121d5358849b5"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -752,9 +751,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-2.0.10-py2-none-any.whl", hash = "sha256:e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31"},
-    {file = "prompt_toolkit-2.0.10-py3-none-any.whl", hash = "sha256:46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4"},
-    {file = "prompt_toolkit-2.0.10.tar.gz", hash = "sha256:f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db"},
+    {file = "prompt_toolkit-3.0.3-py3-none-any.whl", hash = "sha256:c93e53af97f630f12f5f62a3274e79527936ed466f038953dfa379d4941f651a"},
+    {file = "prompt_toolkit-3.0.3.tar.gz", hash = "sha256:a402e9bf468b63314e37460b68ba68243d55b2f8c4d0192f85a019af3945050e"},
 ]
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -484,16 +484,16 @@ description = "Structured Logging for Python"
 name = "structlog"
 optional = false
 python-versions = "*"
-version = "19.2.0"
+version = "20.1.0"
 
 [package.dependencies]
 six = "*"
 
 [package.extras]
-azure-pipelines = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "pytest-azurepipelines", "python-rapidjson"]
-dev = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "sphinx", "twisted", "pre-commit", "python-rapidjson"]
+azure-pipelines = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "pytest-azurepipelines", "python-rapidjson", "pytest-asyncio"]
+dev = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "sphinx", "twisted", "pre-commit", "python-rapidjson", "pytest-asyncio"]
 docs = ["sphinx", "twisted"]
-tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "python-rapidjson"]
+tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "python-rapidjson", "pytest-asyncio"]
 
 [[package]]
 category = "main"
@@ -553,7 +553,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 full = ["PyQt5", "PyQtWebEngine"]
 
 [metadata]
-content-hash = "204874b04444580c0298f9b15dad8f2d335c6725b5549cf5d753776c65a6a60a"
+content-hash = "605912e67827a3043c9c7153fb17848ad86fcfa5c9581ffb03af7fb14ee2513b"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -859,8 +859,8 @@ six = [
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
 ]
 structlog = [
-    {file = "structlog-19.2.0-py2.py3-none-any.whl", hash = "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"},
-    {file = "structlog-19.2.0.tar.gz", hash = "sha256:4287058cf4ce1a59bc5dea290d6386d37f29a37529c9a51cdf7387e51710152b"},
+    {file = "structlog-20.1.0-py2.py3-none-any.whl", hash = "sha256:8a672be150547a93d90a7d74229a29e765be05bd156a35cdcc527ebf68e9af92"},
+    {file = "structlog-20.1.0.tar.gz", hash = "sha256:7a48375db6274ed1d0ae6123c486472aa1d0890b08d314d2b016f3aa7f35990b"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,7 +56,7 @@ version = "2019.11.28"
 [[package]]
 category = "main"
 description = "Foreign Function Interface for Python calling C code."
-marker = "sys_platform == \"linux\" and python_version >= \"3.5\""
+marker = "sys_platform == \"linux\""
 name = "cffi"
 optional = false
 python-versions = "*"
@@ -114,7 +114,7 @@ coverage = "*"
 [[package]]
 category = "main"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-marker = "sys_platform == \"linux\" and python_version >= \"3.5\""
+marker = "sys_platform == \"linux\""
 name = "cryptography"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
@@ -150,14 +150,6 @@ pgp = ["gpg"]
 
 [[package]]
 category = "main"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -183,7 +175,7 @@ testing = ["packaging", "importlib-resources"]
 [[package]]
 category = "main"
 description = "Low-level, pure Python DBus protocol wrapper."
-marker = "sys_platform == \"linux\" and python_version >= \"3.5\""
+marker = "sys_platform == \"linux\""
 name = "jeepney"
 optional = false
 python-versions = ">=3.5"
@@ -197,20 +189,21 @@ category = "main"
 description = "Store and access your passwords safely."
 name = "keyring"
 optional = false
-python-versions = ">=2.7"
-version = "18.0.1"
+python-versions = ">=3.6"
+version = "21.1.0"
 
 [package.dependencies]
-entrypoints = "*"
+SecretStorage = ">=3"
+jeepney = ">=0.4.2"
 pywin32-ctypes = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1"
 
-[package.dependencies.secretstorage]
-python = ">=3.5"
+[package.dependencies.importlib-metadata]
+python = "<3.8"
 version = "*"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
 
 [[package]]
 category = "main"
@@ -280,7 +273,7 @@ version = "1.8.1"
 [[package]]
 category = "main"
 description = "C parser in Python"
-marker = "sys_platform == \"linux\" and python_version >= \"3.5\""
+marker = "sys_platform == \"linux\""
 name = "pycparser"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -443,7 +436,7 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 [[package]]
 category = "main"
 description = "Python bindings to FreeDesktop.org Secret Service API"
-marker = "sys_platform == \"linux\" and python_version >= \"3.5\""
+marker = "sys_platform == \"linux\""
 name = "secretstorage"
 optional = false
 python-versions = ">=3.5"
@@ -552,7 +545,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 full = ["PyQt5", "PyQtWebEngine"]
 
 [metadata]
-content-hash = "4665b3755c630c530496c2b98f82dbad930a8c452ee781a7108121d5358849b5"
+content-hash = "5bfac8301b247e8a67113d089d166e4c616eb178bd2fad6c31c939164e0df7c6"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -689,10 +682,6 @@ dulwich = [
     {file = "dulwich-0.19.15-py3-none-any.whl", hash = "sha256:3285366eb2e97ee89ac4715d24f8c66aff78f7c7040f2b1c3d7cfc8973293ced"},
     {file = "dulwich-0.19.15.tar.gz", hash = "sha256:805a9b1932dc28b91f359f529c2e46b7623aec3ab719c96d3f2fc63d0d8d8411"},
 ]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
-]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
     {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
@@ -706,8 +695,8 @@ jeepney = [
     {file = "jeepney-0.4.2.tar.gz", hash = "sha256:0ba6d8c597e9bef1ebd18aaec595f942a264e25c1a48f164d46120eacaa2e9bb"},
 ]
 keyring = [
-    {file = "keyring-18.0.1-py2.py3-none-any.whl", hash = "sha256:7b29ebfcf8678c4da531b2478a912eea01e80007e5ddca9ee0c7038cb3489ec6"},
-    {file = "keyring-18.0.1.tar.gz", hash = "sha256:67d6cc0132bd77922725fae9f18366bb314fd8f95ff4d323a4df41890a96a838"},
+    {file = "keyring-21.1.0-py2.py3-none-any.whl", hash = "sha256:24ae23ab2d6adc59138339e56843e33ec7b0a6b2f06302662477085c6c0aca00"},
+    {file = "keyring-21.1.0.tar.gz", hash = "sha256:1f393f7466314068961c7e1d508120c092bd71fa54e3d93b76180b526d4abc56"},
 ]
 lxml = [
     {file = "lxml-4.5.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0701f7965903a1c3f6f09328c1278ac0eee8f56f244e66af79cb224b7ef3801c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,12 +20,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
+version = "19.3.0"
 
 [package.extras]
-dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface", "sphinx", "pre-commit"]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
 docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
 category = "dev"
@@ -552,7 +553,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 full = ["PyQt5", "PyQtWebEngine"]
 
 [metadata]
-content-hash = "bf8e03d18548141b799c3da9eed01380dbf0237e7f94e1f42d59c7a7a2d99558"
+content-hash = "204874b04444580c0298f9b15dad8f2d335c6725b5549cf5d753776c65a6a60a"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -565,8 +566,8 @@ atomicwrites = [
     {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
 ]
 attrs = [
-    {file = "attrs-19.1.0-py2.py3-none-any.whl", hash = "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79"},
-    {file = "attrs-19.1.0.tar.gz", hash = "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"},
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 black = [
     {file = "black-19.3b0-py36-none-any.whl", hash = "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ openconnect-sso = "openconnect_sso.cli:main"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-attrs = ">=18.2, <19.2.0"
+attrs = ">=18.2, <=19.3.0"
 colorama = "^0.4"
 importlib-metadata = { version = "^1.4.0", python = "<3.8" }
 lxml = "^4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ colorama = "^0.4"
 importlib-metadata = { version = "^1.4.0", python = "<3.8" }
 lxml = "^4.3"
 keyring = "^18.0"
-prompt-toolkit = "^2.0"
+prompt-toolkit = "^3.0.3"
 pyxdg = "^0.26"
 requests = "^2.22"
 structlog = "^20.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keyring = "^18.0"
 prompt-toolkit = "^2.0"
 pyxdg = "^0.26"
 requests = "^2.22"
-structlog = "^19.1"
+structlog = "^20.1"
 toml = "^0.10"
 setuptools = ">40.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ attrs = ">=18.2, <=19.3.0"
 colorama = "^0.4"
 importlib-metadata = { version = "^1.4.0", python = "<3.8" }
 lxml = "^4.3"
-keyring = "^18.0"
+keyring = "^21.1"
 prompt-toolkit = "^3.0.3"
 pyxdg = "^0.26"
 requests = "^2.22"


### PR DESCRIPTION
Hello,

I wanted to create an [Arch Linux package](https://aur.archlinux.org/packages/openconnect-sso/) for those who don't want to install openconnect-sso via pip.  This requires all dependencies to be updated to the latest version.

The PR bumps the major version of the following dependencies, and follows their incompatible changes:

- `attrs = ">=18.2, <=19.3.0"`  I might not get the gist here. v19.3.0 removed `convert`, but to me, it just seems like a rename (`convert -> converter`):  python-attrs/attrs#307
- `prompt-toolkit = "^3.0.3"` asyncio changes: https://python-prompt-toolkit.readthedocs.io/en/master/pages/upgrading/3.0.html
- `keyring = "^21.1"`
- `structlog = "^20.1"`

Creating an AUR package is probably stupid when there are nice tools like `pipx`, which creates the venv for me and makes everything work like a charm, but I already did it anyway...

Please just close the pull request if my changes cause more problems than they solve.