### PR TITLE
Fix nix overlay

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,3 @@
 self: super: {
-  inherit (super.callPackage ./lib.nix { pkgs = self; }) openconnect-sso;
+  inherit (super.callPackage ./nix { pkgs = self; }) openconnect-sso;
 }


### PR DESCRIPTION
Not entirely sure I did this correctly, but changing `lib.nix` to `nix` seems to work.