### PR TITLE
config: use keyring.get_password() as a workaround for a kwallet bug

### DIFF
--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -99,7 +99,7 @@ class Credentials(ConfigNode):
 
     @property
     def password(self):
-        return keyring.get_credential(APP_NAME, self.username).password
+        return keyring.get_password(APP_NAME, self.username)
 
     @password.setter
     def password(self, value):


### PR DESCRIPTION
The current implementation of the keyring KWallet backend contains a regression that breaks the autofill feature of openconnect-sso:
`get_credential()` returns the password as a string.

https://github.com/jaraco/keyring/commit/0b7b41f93f66ab11038ff50993cb43e9bf1f64af
(I'm about to report and fix this upstream.)

Using `get_password()` is sufficient in my opinion.