### PR TITLE
Allow configuring a command to be automatically run when disconnecting from VPN (take 2)

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shlex
 import signal
+import subprocess
 from pathlib import Path
 
 import structlog
@@ -25,20 +26,57 @@ logger = structlog.get_logger()
 def run(args):
     configure_logger(logging.getLogger(), args.log_level)
 
+    cfg = config.load()
+
     try:
         if os.name == "nt":
             asyncio.set_event_loop(asyncio.ProactorEventLoop())
-        return asyncio.get_event_loop().run_until_complete(_run(args))
+        auth_response, selected_profile = asyncio.get_event_loop().run_until_complete(
+            _run(args, cfg)
+        )
     except KeyboardInterrupt:
         logger.warn("CTRL-C pressed, exiting")
+        return 130
+    except ValueError as e:
+        msg, retval = e.args
+        logger.error(msg)
+        return retval
     except Terminated:
         logger.warn("Browser window terminated, exiting")
+        return 2
     except AuthResponseError as exc:
         logger.error(
             f'Required attributes not found in response ("{exc}", does this endpoint do SSO?), exiting'
         )
+        return 3
     except HTTPError as exc:
         logger.error(f"Request error: {exc}")
+        return 4
+
+    config.save(cfg)
+
+    if args.authenticate:
+        logger.warn("Exiting after login, as requested")
+        details = {
+            "host": selected_profile.vpn_url,
+            "cookie": auth_response.session_token,
+            "fingerprint": auth_response.server_cert_hash,
+        }
+        if args.authenticate == "json":
+            print(json.dumps(details, indent=4))
+        elif args.authenticate == "shell":
+            print(
+                "\n".join(f"{k.upper()}={shlex.quote(v)}" for k, v in details.items())
+            )
+        return 0
+
+    try:
+        return run_openconnect(
+            auth_response, selected_profile, args.proxy, args.openconnect_args
+        )
+    except KeyboardInterrupt:
+        logger.warn("CTRL-C pressed, exiting")
+        return 0
 
 
 def configure_logger(logger, level):
@@ -62,9 +100,7 @@ def configure_logger(logger, level):
     logger.setLevel(level)
 
 
-async def _run(args):
-    cfg = config.load()
-
+async def _run(args, cfg):
     credentials = None
     if cfg.credentials:
         credentials = cfg.credentials
@@ -78,49 +114,29 @@ async def _run(args):
     elif args.use_profile_selector or args.profile_path:
         profiles = get_profiles(Path(args.profile_path))
         if not profiles:
-            logger.error("No profile found")
-            return 17
+            raise ValueError("No profile found", 17)
 
         selected_profile = await select_profile(profiles)
         if not selected_profile:
-            logger.error("No profile selected")
-            return 18
+            raise ValueError("No profile selected", 18)
     elif args.server:
         selected_profile = config.HostProfile(
             args.server, args.usergroup, args.authgroup
         )
     else:
         raise ValueError(
-            "Cannot determine server address. Invalid arguments specified."
+            "Cannot determine server address. Invalid arguments specified.", 19
         )
 
     cfg.default_profile = selected_profile
-
-    config.save(cfg)
 
     display_mode = config.DisplayMode[args.browser_display_mode.upper()]
 
     auth_response = await authenticate_to(
         selected_profile, args.proxy, credentials, display_mode
     )
-    if args.authenticate:
-        logger.warn("Exiting after login, as requested")
-        details = {
-            "host": selected_profile.vpn_url,
-            "cookie": auth_response.session_token,
-            "fingerprint": auth_response.server_cert_hash,
-        }
-        if args.authenticate == "json":
-            print(json.dumps(details, indent=4))
-        elif args.authenticate == "shell":
-            print(
-                "\n".join(f"{k.upper()}={shlex.quote(v)}" for k, v in details.items())
-            )
-        return 0
 
-    return await run_openconnect(
-        auth_response, selected_profile, args.proxy, args.openconnect_args
-    )
+    return auth_response, selected_profile
 
 
 async def select_profile(profile_list):
@@ -147,7 +163,7 @@ def authenticate_to(host, proxy, credentials, display_mode):
     return Authenticator(host, proxy, credentials).authenticate(display_mode)
 
 
-async def run_openconnect(auth_info, host, proxy, args):
+def run_openconnect(auth_info, host, proxy, args):
     command_line = [
         "sudo",
         "openconnect",
@@ -162,5 +178,4 @@ async def run_openconnect(auth_info, host, proxy, args):
         command_line.extend(["--proxy", proxy])
 
     logger.debug("Starting OpenConnect", command_line=command_line)
-    proc = await asyncio.create_subprocess_exec(*command_line)
-    await proc.wait()
+    return subprocess.run(command_line).returncode

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -77,6 +77,8 @@ def run(args):
     except KeyboardInterrupt:
         logger.warn("CTRL-C pressed, exiting")
         return 0
+    finally:
+        handle_disconnect(cfg.on_disconnect)
 
 
 def configure_logger(logger, level):
@@ -136,6 +138,9 @@ async def _run(args, cfg):
         selected_profile, args.proxy, credentials, display_mode
     )
 
+    if args.on_disconnect and not cfg.on_disconnect:
+        cfg.on_disconnect = args.on_disconnect
+
     return auth_response, selected_profile
 
 
@@ -179,3 +184,9 @@ def run_openconnect(auth_info, host, proxy, args):
 
     logger.debug("Starting OpenConnect", command_line=command_line)
     return subprocess.run(command_line).returncode
+
+
+def handle_disconnect(command):
+    if command:
+        logger.info("Running command on disconnect", command_line=command)
+        return subprocess.run(command, timeout=5, shell=True).returncode

--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -68,7 +68,7 @@ class Authenticator:
 
     async def _authenticate_in_browser(self, auth_request_response, display_mode):
         return await authenticate_in_browser(
-            auth_request_response, self.credentials, display_mode
+            self.proxy, auth_request_response, self.credentials, display_mode
         )
 
     def _complete_authentication(self, auth_request_response, sso_token):

--- a/openconnect_sso/cli.py
+++ b/openconnect_sso/cli.py
@@ -80,6 +80,12 @@ def create_argparser():
     )
 
     parser.add_argument(
+        "--on-disconnect",
+        help="Command to run when disconnecting from VPN server",
+        default="",
+    )
+
+    parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
     )
 

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -35,15 +35,14 @@ def load():
 def save(config):
     path = xdg.BaseDirectory.save_config_path(APP_NAME)
     config_path = Path(path) / "config.toml"
-    config_path.touch()
-
-    with config_path.open("w") as config_file:
-        try:
+    try:
+        config_path.touch()
+        with config_path.open("w") as config_file:
             toml.dump(config.as_dict(), config_file)
-        except Exception:
-            logger.error(
-                "Could not save configuration file", path=config_path, exc_info=True
-            )
+    except Exception:
+        logger.error(
+            "Could not save configuration file", path=config_path, exc_info=True
+        )
 
 
 @attr.s

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -115,6 +115,7 @@ class Config(ConfigNode):
             n: [AutoFillRule.from_dict(r) for r in rule] for n, rule in rules.items()
         },
     )
+    on_disconnect = attr.ib(converter=str, default="")
 
 
 class DisplayMode(enum.Enum):


### PR DESCRIPTION
I configure my SSH with ControlMaster connections that must be closed when I disconnect from VPN, otherwise they are left stale and existing and future SSH session are left hanging/wedged.

To accomodate this, the last patch in this series teaches openconnect-sso automatically run a configured command on VPN disconnection. In my case, I run a shell script that does `ssh -O exit ...` on my connections, although this doesn't matter from openconnect-sso's POV.

Otherwise the other patches are only tangentially related:
- Patch#1 fixes an obvious bug in the `develop` branch.
- Patch#2 stops openconnect-sso from crashing when the config file cannot be written. It allows me to control the openconnect-sso configuration via [home-manager](https://github.com/nix-community/home-manager) (which stores a symlink to a read-only file in the Nix store).
- Patch#3 moves code from the async `_run()` into the sync `run()`. Specifically it moves the running of the `openconnect` subprocess which does not benefit from being async. This also fixes the control flow when aborting `openconnect` with `Ctrl+C`.

This supersedes https://github.com/vlaci/openconnect-sso/pull/32, but is based on `develop` instead of `master`, as I found it easier to get this done on top of those changes.