### PR TITLE
app.py: pipe session token via stdin instead of using command args

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -174,8 +174,7 @@ def run_openconnect(auth_info, host, proxy, args):
     command_line = [
         "sudo",
         "openconnect",
-        "--cookie",
-        auth_info.session_token,
+        "--cookie-on-stdin",
         "--servercert",
         auth_info.server_cert_hash,
         *args,
@@ -184,8 +183,9 @@ def run_openconnect(auth_info, host, proxy, args):
     if proxy:
         command_line.extend(["--proxy", proxy])
 
+    session_token = auth_info.session_token.encode("utf-8")
     logger.debug("Starting OpenConnect", command_line=command_line)
-    return subprocess.run(command_line).returncode
+    return subprocess.run(command_line, input=session_token).returncode
 
 
 def handle_disconnect(command):


### PR DESCRIPTION
Passing session cookie value via the command line isn't safe because any user
on the same machine can see this value. Instead of passing it via command args,
this change uses `--cookie-on-stdin` flag and passes the session cookie via
stdin.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>