### PR TITLE
Support for automated filling of TOTP and updated AutoFillRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Configuration is saved in `$XDG_CONFIG_HOME/openconnect-sso/config.toml`. On
 typical Linux installations it is located under
 `$HOME/.config/openconnect-sso/config.toml`
 
+For CISCO-VPN and TOTP the following seems to work by tuning the config.toml
+and removing the default "submit"-action to the following:
+
+```
+[[auto_fill_rules."https://*"]]
+selector = "input[data-report-event=Signin_Submit]"
+action = "click"
+
+[[auto_fill_rules."https://*"]]
+selector = "input[type=tel]"
+fill = "totp"
+```
+
 ## Development
 
 `openconnect-sso` is developed using [Nix](https://nixos.org/nix/). Refer to the

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -113,6 +113,12 @@ async def _run(args, cfg):
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")
         cfg.credentials = credentials
 
+    if credentials and not credentials.totp:
+        credentials.totp = getpass.getpass(
+            prompt=f"TOTP secret (leave blank if not required) ({args.user}): "
+        )
+        cfg.credentials = credentials
+
     if cfg.default_profile and not (args.use_profile_selector or args.server):
         selected_profile = cfg.default_profile
     elif args.use_profile_selector or args.profile_path:

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -89,11 +89,17 @@ def get_default_auto_fill_rules():
         "https://*": [
             AutoFillRule(selector="div[id=passwordError]", action="stop").as_dict(),
             AutoFillRule(selector="input[type=email]", fill="username").as_dict(),
-            AutoFillRule(selector="input[type=password]", fill="password").as_dict(),
+            AutoFillRule(selector="input[name=passwd]", fill="password").as_dict(),
             AutoFillRule(
                 selector="input[data-report-event=Signin_Submit]", action="click"
             ).as_dict(),
-            AutoFillRule(selector="input[type=tel]", fill="totp").as_dict(),
+            AutoFillRule(
+                selector="div[data-value=PhoneAppOTP]", action="click"
+            ).as_dict,
+            AutoFillRule(selector="a[id=signInAnotherWay]", action="click").as_dict,
+            AutoFillRule(
+                selector="input[id=idTxtBx_SAOTCC_OTC]", fill="totp"
+            ).as_dict(),
         ]
     }
 
@@ -120,7 +126,7 @@ class Credentials(ConfigNode):
     @property
     def totp(self):
         try:
-            totpsecret = keyring.get_password(APP_NAME + "_TOTP", self.username)
+            totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
             return pyotp.TOTP(totpsecret).now()
         except keyring.errors.KeyringError:
             logger.info("Cannot retrieve saved totp info from keyring.")
@@ -129,7 +135,7 @@ class Credentials(ConfigNode):
     @totp.setter
     def totp(self, value):
         try:
-            keyring.set_password(APP_NAME + "_TOTP", self.username, value)
+            keyring.set_password(APP_NAME, "totp/" + self.username, value)
         except keyring.errors.KeyringError:
             logger.info("Cannot save totp secret to keyring.")
 

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -90,7 +90,9 @@ def get_default_auto_fill_rules():
             AutoFillRule(selector="div[id=passwordError]", action="stop").as_dict(),
             AutoFillRule(selector="input[type=email]", fill="username").as_dict(),
             AutoFillRule(selector="input[type=password]", fill="password").as_dict(),
-            AutoFillRule(selector="input[type=submit]", action="click").as_dict(),
+            AutoFillRule(
+                selector="input[data-report-event=Signin_Submit]", action="click"
+            ).as_dict(),
             AutoFillRule(selector="input[type=tel]", fill="totp").as_dict(),
         ]
     }

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -16,7 +16,6 @@ logger = structlog.get_logger()
 APP_NAME = "openconnect-sso"
 
 
-
 def load():
     path = xdg.BaseDirectory.load_first_config(APP_NAME)
     if not path:
@@ -119,7 +118,7 @@ class Credentials(ConfigNode):
     @property
     def totp(self):
         try:
-            totpsecret = keyring.get_password(APP_NAME+'_TOTP', self.username)
+            totpsecret = keyring.get_password(APP_NAME + "_TOTP", self.username)
             return pyotp.TOTP(totpsecret).now()
         except keyring.errors.KeyringError:
             logger.info("Cannot retrieve saved totp info from keyring.")
@@ -128,10 +127,9 @@ class Credentials(ConfigNode):
     @totp.setter
     def totp(self, value):
         try:
-            keyring.set_password(APP_NAME+'_TOTP', self.username, value)
+            keyring.set_password(APP_NAME + "_TOTP", self.username, value)
         except keyring.errors.KeyringError:
             logger.info("Cannot save totp secret to keyring.")
-
 
 
 @attr.s

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -127,7 +127,7 @@ class Credentials(ConfigNode):
     def totp(self):
         try:
             totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
-            return pyotp.TOTP(totpsecret).now()
+            return pyotp.TOTP(totpsecret).now() if totpsecret else None
         except keyring.errors.KeyringError:
             logger.info("Cannot retrieve saved totp info from keyring.")
             return ""


### PR DESCRIPTION
Support for generating the TOTP-value by fetching the TOTP-secret as password from the keyring with a totp/ prefix to the username. Also updated AutoFillRules to use more robust fields and avoid "click" on incorrect links in the web prompts. Default is to prefer the "other" Authenticator app, which allows for retrieving the TOTP secret from the QR-code.  Which 2FA presented to the user depends on the user preference set in mysignins.microsoft.com/security-info.