### PR TITLE
Allow to specify AnyConnect version via CLI flag

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -72,7 +72,7 @@ def run(args):
 
     try:
         return run_openconnect(
-            auth_response, selected_profile, args.proxy, args.openconnect_args
+            auth_response, selected_profile, args.proxy, args.ac_version, args.openconnect_args
         )
     except KeyboardInterrupt:
         logger.warn("CTRL-C pressed, exiting")
@@ -174,13 +174,13 @@ def run_openconnect(auth_info, host, proxy, version, args):
     command_line = [
         "sudo",
         "openconnect",
-        "--cookie-on-stdin",
-        "--servercert",
-        auth_info.server_cert_hash,
         "--useragent",
         f"AnyConnect Linux_64 {version}",
         "--version-string",
         version,
+        "--cookie-on-stdin",
+        "--servercert",
+        auth_info.server_cert_hash,
         *args,
         host.vpn_url,
     ]

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -72,7 +72,11 @@ def run(args):
 
     try:
         return run_openconnect(
-            auth_response, selected_profile, args.proxy, args.ac_version, args.openconnect_args
+            auth_response,
+            selected_profile,
+            args.proxy,
+            args.ac_version,
+            args.openconnect_args,
         )
     except KeyboardInterrupt:
         logger.warn("CTRL-C pressed, exiting")

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -137,7 +137,7 @@ async def _run(args, cfg):
     display_mode = config.DisplayMode[args.browser_display_mode.upper()]
 
     auth_response = await authenticate_to(
-        selected_profile, args.proxy, credentials, display_mode
+        selected_profile, args.proxy, credentials, display_mode, args.ac_version
     )
 
     if args.on_disconnect and not cfg.on_disconnect:
@@ -165,18 +165,22 @@ async def select_profile(profile_list):
     return selection
 
 
-def authenticate_to(host, proxy, credentials, display_mode):
+def authenticate_to(host, proxy, credentials, display_mode, version):
     logger.info("Authenticating to VPN endpoint", name=host.name, address=host.address)
-    return Authenticator(host, proxy, credentials).authenticate(display_mode)
+    return Authenticator(host, proxy, credentials, version).authenticate(display_mode)
 
 
-def run_openconnect(auth_info, host, proxy, args):
+def run_openconnect(auth_info, host, proxy, version, args):
     command_line = [
         "sudo",
         "openconnect",
         "--cookie-on-stdin",
         "--servercert",
         auth_info.server_cert_hash,
+        "--useragent",
+        f"AnyConnect Linux_64 {version}",
+        "--version-string",
+        version,
         *args,
         host.vpn_url,
     ]

--- a/openconnect_sso/cli.py
+++ b/openconnect_sso/cli.py
@@ -90,6 +90,12 @@ def create_argparser():
     )
 
     parser.add_argument(
+        "--ac-version",
+        help="AnyConnect Version used for authentication and for OpenConnect, defaults to %(default)s",
+        default="4.7.00136",
+    )
+
+    parser.add_argument(
         "-l",
         "--log-level",
         help="",


### PR DESCRIPTION
In some environments a specific AC version might be required instead of the hard-coded 4.7.00136 and/or whatever OpenConnect provides as the default version string.

This PR inserts the provided AC version both to 

- the initial authentication request
- OpenConnect when establishing the session

