### PR TITLE
update pyxdg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ importlib-metadata = { version = "^3.10.0", python = "<3.8" }
 lxml = "^4.3"
 keyring = ">=21.1, <24.0.0"
 prompt-toolkit = "^3.0.3"
-pyxdg = ">=0.26, <0.28"
+pyxdg = ">=0.26, <0.29"
 requests = "^2.22"
 structlog = ">=20.1"
 toml = "^0.10"


### PR DESCRIPTION
pyxdg v0.28 was released this week, and Arch Linux is now using it.

https://github.com/takluyver/pyxdg/blob/master/ChangeLog

```
Version 0.28 (June 2022)

    * BaseDirectory: Add support for $XDG_STATE_DIR
```