### PR TITLE
config address from server arguments instead of redirect

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -133,17 +133,23 @@ async def _run(args, cfg):
         )
 
     cfg.default_profile = selected_profile
+    
+    working_profile = config.HostProfile(
+            selected_profile.address,
+            selected_profile.user_group,
+            selected_profile.name
+        )
 
     display_mode = config.DisplayMode[args.browser_display_mode.upper()]
 
     auth_response = await authenticate_to(
-        selected_profile, args.proxy, credentials, display_mode
+        working_profile, args.proxy, credentials, display_mode
     )
 
     if args.on_disconnect and not cfg.on_disconnect:
         cfg.on_disconnect = args.on_disconnect
 
-    return auth_response, selected_profile
+    return auth_response, working_profile
 
 
 async def select_profile(profile_list):


### PR DESCRIPTION
Problem:
The VPN address I am connecting to is a load balancer and will redirect me to a subdomain. This subdomain is then saved in the 'address' field of the profile in the config file. When connecting again, this address is used by default to make the connection and results in the user directly connecting to the subdomain rather than load balancer/original URL.
This is due to the configuration file being saved only after the target URL is redirected. After loading/generating the HostProfile object, it is copied to cfg.default_profile. But then, the HostProfile object will have its URL changed by _detect_authentication_target_url() (to be used later for connecting to open-connect and logging). No other aspects of the HostProfile object change after initialization.

Solution:
Set cfg.default_profile to the HostProfile object named selected_profile. Then the selected_profile object will be used to generate an identical HostProfile object called working_profile. This working_profile object will be returned after its 'address' field is resolved so anything using the resolved URL is not impacted. 
Essentially the config that gets saved will maintain the original address that the user submitted when initially connecting to the server, rather than what _detect_authentication_target_url() redirects to.
Avoids re-configuring the config file and does not require any significant changes. Do not need to import a library like copy.

This is my first pull request so please let me know if there is anything I have misconstrued. I realize it is not the best solution but was the best I could figure without significant changes. 