### PR TITLE
save original URL rather than redirect URL

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -132,7 +132,11 @@ async def _run(args, cfg):
             "Cannot determine server address. Invalid arguments specified.", 19
         )
 
-    cfg.default_profile = selected_profile
+    cfg.default_profile = config.HostProfile(
+            selected_profile.address,
+            selected_profile.user_group,
+            selected_profile.name
+        )
 
     display_mode = config.DisplayMode[args.browser_display_mode.upper()]
 


### PR DESCRIPTION
### Idea

Populate config.toml with the original server address the user targeted rather than an address they may have been redirected to.

### Issue

As it stands, if there is redirection to a sub-domain, the sub-domains address will be stored as 'address' in config.toml. Without specifying the server, a subsequent connection is made directly to the sub-domain. 

### Cause

cfg.default_profile is set equal to the selected_profile HostProfile object, but the 'address' attribute is changed on URL redirection before the configuration file is saved.

### Solution

Populate cfg.default_profile with a dereferenced copy of the selected_profile HostProfile object before URL redirection changes selected_profile's 'address' attribute.

### Thoughts

No other attributes of the selected_profile HostProfile object are modified after this copy takes place. No changes to the conditions of configuration saving. 

### Alternative
cfg.default_profile = config.HostProfile.from_dict(selected_profile.as_dict())
- Same solution but would help preserve any future attributes added to the config/profile.