### PR TITLE
Fix openconnect-sso running under windows

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -172,7 +172,7 @@ def authenticate_to(host, proxy, credentials, display_mode):
 
 def run_openconnect(auth_info, host, proxy, args):
     command_line = [
-        "sudo",
+        "sudo" if os.name != "nt" else "sudo.cmd",
         "openconnect",
         "--cookie-on-stdin",
         "--servercert",


### PR DESCRIPTION
At least when using scoop to install sudo. I'm not sure if others use other methods to have a working system for `sudo` on windows