### PR TITLE
Remove deprecated pytestrunner alias

### DIFF
--- a/nix/openconnect-sso.nix
+++ b/nix/openconnect-sso.nix
@@ -39,7 +39,7 @@ poetry2nix.mkPoetryApplication {
         };
         pytest-httpserver = super.pytest-httpserver.overrideAttrs (
           old: {
-            nativeBuildInputs = old.nativeBuildInputs ++ [ self.pytestrunner ];
+            nativeBuildInputs = old.nativeBuildInputs ++ [ self.pytest-runner ];
           }
         );
       }


### PR DESCRIPTION
The package doesn't build anymore after [this commit](https://github.com/NixOS/nixpkgs/commit/ddb7c7bd95a25d7c4101ee111d20fe16446d947c#diff-4878bf3fa499d7d0bab51ebe52427ba7ee884458535a7bbae5e31f245994dbf8R142) on NixOS.
This PR renames the alias which fixes the build of the package on a recent NixOS version.
Fixes #98