### PR TITLE
Fix for too much openconnect argument

### DIFF
--- a/openconnect_sso/cli.py
+++ b/openconnect_sso/cli.py
@@ -116,7 +116,7 @@ class StoreOpenConnectArgs(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if "--" in values:
             values.remove("--")
-        setattr(namespace, self.dest, values)
+        setattr(namespace, self.dest, values[1:])
 
 
 class LogLevel(enum.IntEnum):


### PR DESCRIPTION
in app.py, it passing argument name(openconnect_args) itself to openconnect.  Therefore, when this argument is used, OpenConnect is receiving the wrong argument openconnect_args and it leads below problem. https://github.com/vlaci/openconnect-sso/issues/30

Hence, I change the openconnect_args parser not to store the first argument(which is openconnect_args)