### PR TITLE
Allow running without 'sudo' binary on windows when running as admin.

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -184,15 +184,22 @@ def authenticate_to(host, proxy, credentials, display_mode, version):
 
 
 def run_openconnect(auth_info, host, proxy, version, args):
-    as_root = next((prog for prog in ("doas", "sudo") if shutil.which(prog)), None)
-    if not as_root:
-        logger.error(
-            "Cannot find suitable program to execute as superuser (doas/sudo), exiting"
-        )
-        return 20
+    as_root = next(([prog] for prog in ("doas", "sudo") if shutil.which(prog)), [])
+    try:
+        if not as_root:
+            if os.name == 'nt':
+                import ctypes
+                if not ctypes.windll.shell32.IsUserAnAdmin():
+                    raise PermissionError
+            else:
+                raise PermissionError
+    except:
+            logger.error(
+                "Cannot find suitable program to execute as superuser (doas/sudo), exiting"
+            )
+            return 20
 
-    command_line = [
-        as_root,
+    command_line = as_root + [
         "openconnect",
         "--useragent",
         f"AnyConnect Linux_64 {version}",


### PR DESCRIPTION
sudo binary is not normally present on windows.
Ignore the error if already running as admin.