### PR TITLE
Added initial flake support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,1 @@
-(import ./nix {}).openconnect-sso
+(import ./nix { }).openconnect-sso

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1622445595,
+        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622282707,
+        "narHash": "sha256-+GOrUDsdneUqrOm9d+9bHXjEVoVcU8tm14WGVzbt6gg=",
+        "path": "/nix/store/9za793c35j4rnawwf2n2wpbwwnah1rq9-source",
+        "rev": "6933d068c5d2fcff398e802f7c4e271bbdab6705",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }: (flake-utils.lib.eachDefaultSystem (
+    system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      openconnect-sso = (import ./nix { inherit pkgs; }).openconnect-sso;
+    in
+    {
+      packages = { inherit openconnect-sso; };
+      defaultPackage = openconnect-sso;
+    }
+  ) // {
+      overlay = import ./overlay.nix;
+  });
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,8 @@ let
       qtbase = head (filter (d: getName d.name == "qtbase") dep.nativeBuildInputs);
       version = splitVersion qtbase.version;
       majorMinor = concatStrings (take 2 version);
-    in pkgs."libsForQt${majorMinor}";
+    in
+    pkgs."libsForQt${majorMinor}";
 
   inherit (qtLibsFor pkgs.python3Packages.pyqt5) callPackage;
   pythonPackages = pkgs.python3Packages;

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -30,7 +30,8 @@ let
 
           $ niv modify <package> -a type=tarball -a builtin=true
       ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+      builtins_fetchTarball
+      { inherit (spec) url sha256; };
 
   fetch_builtin-url = spec:
     builtins.trace
@@ -58,19 +59,20 @@ let
     if hasNixpkgsPath
     then
       if hasThisAsNixpkgsPath
-      then import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) {}
-      else import <nixpkgs> {}
+      then import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) { }
+      else import <nixpkgs> { }
     else
-      import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) {};
+      import (builtins_fetchTarball { inherit (sources_nixpkgs) url sha256; }) { };
 
   sources_nixpkgs =
     if builtins.hasAttr "nixpkgs" sources
     then sources.nixpkgs
-    else abort
-      ''
-        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-        add a package called "nixpkgs" to your sources.json.
-      '';
+    else
+      abort
+        ''
+          Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+          add a package called "nixpkgs" to your sources.json.
+        '';
 
   hasNixpkgsPath = (builtins.tryEval <nixpkgs>).success;
   hasThisAsNixpkgsPath =
@@ -102,27 +104,30 @@ let
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
-      if lessThan nixVersion "1.12" then
-        fetchTarball { inherit url; }
-      else
-        fetchTarball attrs;
+    if lessThan nixVersion "1.12" then
+      fetchTarball { inherit url; }
+    else
+      fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
   builtins_fetchurl = { url, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
-      if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
-      else
-        fetchurl attrs;
+    if lessThan nixVersion "1.12" then
+      fetchurl { inherit url; }
+    else
+      fetchurl attrs;
 
 in
-mapAttrs (
-  name: spec:
-    if builtins.hasAttr "outPath" spec
-    then abort
-      "The values in sources.json should not have an 'outPath' attribute"
-    else
-      spec // { outPath = fetch name spec; }
-) sources
+mapAttrs
+  (
+    name: spec:
+      if builtins.hasAttr "outPath" spec
+      then
+        abort
+          "The values in sources.json should not have an 'outPath' attribute"
+      else
+        spec // { outPath = fetch name spec; }
+  )
+  sources

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,3 @@
-self: super: {
-  inherit (super.callPackage ./nix { pkgs = self; }) openconnect-sso;
+final: prev: {
+  inherit (prev.callPackage ./nix { pkgs = final; }) openconnect-sso;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./nix {}).shell
+(import ./nix { }).shell


### PR DESCRIPTION
Rebased from earlier `flake` branch. This branch reapplies `nixpkgs-fmt` code cleanup then cherry-picks the "nix: flake support".

The current state of flakes support is rather primitive. The nix code depends on packages from nixpkgs-unstable e.g. `pyqt6`. For now, users of stable nixpkgs should add the `openconnect-sso` overlay to nixpkgs-unstable, and combine it with the reset of their packages from nixpkgs-22.11.

Here is an example `flake.nix` for a NixOS system:
```
{
  inputs = {
    nixpkgs.url = "nixpkgs/nixos-22.11";
    nixpkgsUnstable.url = "nixpkgs/nixos-unstable";
    openconnect-sso.url = "/home/jholdsworth/Downloads/openconnect-sso";
  };

  outputs = { self, nixpkgs, nixpkgsUnstable, openconnect-sso }:
  let
    inherit (nixpkgs) lib;

    system = "x86_64-linux";
    
    pkgs = import nixpkgs {
      inherit system;
    };

    pkgsUnstable = import nixpkgsUnstable {
      inherit system;
      overlays = [ openconnect-sso.overlay ];
    };
  in {
    nixosConfigurations.sail = lib.nixosSystem {
      inherit system;

      modules = [
        {
          environment.systemPackages = [
            pkgsUnstable.openconnect-sso
            # Stable packages... 
            pkgs.hello
          ];

          # ...
      ];
    };
  };
}

```

After the release of nixpkgs-23.05, the usage of nixpkgs-unstable will no longer be necessary.