### PR TITLE
Allow legacy renegotiation

### DIFF
--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -2,6 +2,9 @@ import attr
 import requests
 import structlog
 from lxml import etree, objectify
+import ssl
+from requests import adapters
+import urllib3
 
 from openconnect_sso.saml_authenticator import authenticate_in_browser
 
@@ -54,7 +57,7 @@ class Authenticator:
     def _detect_authentication_target_url(self):
         # Follow possible redirects in a GET request
         # Authentication will occcur using a POST request on the final URL
-        response = requests.get(self.host.vpn_url)
+        response = self.session.get(self.host.vpn_url, verify=False)
         response.raise_for_status()
         self.host.address = response.url
         logger.debug("Auth target url", url=self.host.vpn_url)
@@ -89,8 +92,33 @@ class AuthResponseError(AuthenticationError):
     pass
 
 
+class LegacyHTTPAdapter(adapters.HTTPAdapter):
+    """“Transport adapter” that allows us to use legacy renogation.
+
+    Such renegotiation is disabled by default in OpenSSL 3.0. This
+    suppresses errors such as:
+
+      SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe
+      legacy renegotiation disabled (_ssl.c:992)')
+
+    """
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        ctx = urllib3.util.ssl_.create_urllib3_context()
+        ctx.load_default_certs()
+        ctx.options |= 0x4  # ssl.OP_LEGACY_SERVER_CONNECT
+
+        self.poolmanager = urllib3.PoolManager(
+            ssl_context=ctx,
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+        )
+
+
 def create_http_session(proxy):
     session = requests.Session()
+    session.mount("https://", LegacyHTTPAdapter())
     session.proxies = {"http": proxy, "https": proxy}
     session.headers.update(
         {

--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -57,10 +57,18 @@ class Authenticator:
     def _detect_authentication_target_url(self):
         # Follow possible redirects in a GET request
         # Authentication will occcur using a POST request on the final URL
-        response = self.session.get(self.host.vpn_url, verify=False)
-        response.raise_for_status()
-        self.host.address = response.url
         logger.debug("Auth target url", url=self.host.vpn_url)
+        response = self.session.get(self.host.vpn_url, verify=False)
+        if response.ok:
+            self.host.address = response.url
+        else:
+            logger.warn(
+                "Failed to check for redirect",
+                reason=response.reason,
+                error=response.status_code,
+                response=response,
+            )
+            self.host.address = self.host.vpn_url
 
     def _start_authentication(self):
         request = _create_auth_init_request(self.host, self.host.vpn_url)


### PR DESCRIPTION
When trying out OpenConnect SSO on my Mac using OpenSSL 3, I get the follow error:

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='<redacted>', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:992)')))
```

I addressed this by using setting the relevant flag on the SSL context. In addition, the redirect detection seemed to fail, so I suppressed the error and issued a warning instead. With those changes, I was able to connect to the VPN in question.

(Please note that this branch is based off the latest release, as I don't have PyQt6 installed at the moment. There's another branch in my fork that's based on `master`.)