### PR TITLE
Update poetry2nix version 1.35.0 -> 1.41.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {
-        "branch": "1.35.0",
+        "branch": "1.41.0",
         "description": "Convert poetry projects to nix automagically [maintainer=@adisbladis] ",
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "d62ba59f1e28c382665c57203a4b9ad11fd7f449",
-        "sha256": "1ajkw5f964p7grmkqnpv97xahxrfn6ck8d9mb26r9sxk499bahc0",
+        "rev": "585f19cce38a7f75d5bc567b17060ec45bc63ed0",
+        "sha256": "0dj2a1wzcyilrc9fmfffx6d3bgq7zpawjadd7rphkkq8imh18y6a",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/d62ba59f1e28c382665c57203a4b9ad11fd7f449.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/585f19cce38a7f75d5bc567b17060ec45bc63ed0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Fixes error with more recent nixpkgs and old poetry2nix version; namely "removePathDependenciesHook should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set."

First time contributor here; let me know if anything needs to be changed.  Thanks for the nix support, by the way.