### PR TITLE
fixed bugs where first openconnect arg is deleted

### DIFF
--- a/openconnect_sso/cli.py
+++ b/openconnect_sso/cli.py
@@ -122,7 +122,7 @@ class StoreOpenConnectArgs(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if "--" in values:
             values.remove("--")
-        setattr(namespace, self.dest, values[1:])
+        setattr(namespace, self.dest, values[0:])
 
 
 class LogLevel(enum.IntEnum):


### PR DESCRIPTION
have not really double checked all possible inputs here, but this patch fixes the where where given the cli arguments; 
`openconnect-sso .. -- args1topenconnect`
where both https://github.com/vlaci/openconnect-sso/blob/master/openconnect_sso/cli.py#L124 and https://github.com/vlaci/openconnect-sso/blob/master/openconnect_sso/cli.py#L125 removes the first argument - effectively removing two arguments "--" and "args1openconnect"..