### PR TITLE
Add password & totp arguments to the cli and enable hacks for duo 2fa injection

### DIFF
--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -122,7 +122,7 @@ async def _run(args, cfg):
         cfg.credentials = credentials
 
     if credentials and not credentials.totp and args.totp:
-        credentials.totp = args.totp
+        credentials.totp = args._totp
         cfg.credentials = credentials
     elif credentials and not credentials.totp:
         credentials.totp = getpass.getpass(

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -114,11 +114,17 @@ async def _run(args, cfg):
     elif args.user:
         credentials = Credentials(args.user)
 
-    if credentials and not credentials.password:
+    if credentials and not credentials.password and args.passwd:
+        credentials.password = args.passwd
+        cfg.credentials = credentials
+    elif credentials and not credentials.password:
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")
         cfg.credentials = credentials
 
-    if credentials and not credentials.totp:
+    if credentials and not credentials.totp and args.totp:
+        credentials.totp = args.totp
+        cfg.credentials = credentials
+    elif credentials and not credentials.totp:
         credentials.totp = getpass.getpass(
             prompt=f"TOTP secret (leave blank if not required) ({args.user}): "
         )

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -115,14 +115,14 @@ async def _run(args, cfg):
         credentials = Credentials(args.user)
 
     if credentials and not credentials.password and args.passwd:
-        credentials.password = (args.passwd, False)
+        credentials.passwd = args.passwd
         cfg.credentials = credentials
     elif credentials and not credentials.password:
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")
         cfg.credentials = credentials
 
     if credentials and not credentials.totp and args.totp:
-        credentials.totp = (args.totp, False)
+        credentials.totp = args.totp
         cfg.credentials = credentials
     elif credentials and not credentials.totp:
         credentials.totp = getpass.getpass(

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -115,7 +115,7 @@ async def _run(args, cfg):
         credentials = Credentials(args.user)
 
     if credentials and not credentials.password and args.passwd:
-        credentials.passwd = args.passwd
+        credentials._passwd = args.passwd
         cfg.credentials = credentials
     elif credentials and not credentials.password:
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -115,14 +115,14 @@ async def _run(args, cfg):
         credentials = Credentials(args.user)
 
     if credentials and not credentials.password and args.passwd:
-        credentials.password = args.passwd
+        credentials.password = (args.passwd, False)
         cfg.credentials = credentials
     elif credentials and not credentials.password:
         credentials.password = getpass.getpass(prompt=f"Password ({args.user}): ")
         cfg.credentials = credentials
 
     if credentials and not credentials.totp and args.totp:
-        credentials.totp = args.totp
+        credentials.totp = (args.totp, False)
         cfg.credentials = credentials
     elif credentials and not credentials.totp:
         credentials.totp = getpass.getpass(

--- a/openconnect_sso/app.py
+++ b/openconnect_sso/app.py
@@ -122,7 +122,7 @@ async def _run(args, cfg):
         cfg.credentials = credentials
 
     if credentials and not credentials.totp and args.totp:
-        credentials.totp = args._totp
+        credentials._totp = args.totp
         cfg.credentials = credentials
     elif credentials and not credentials.totp:
         credentials.totp = getpass.getpass(

--- a/openconnect_sso/browser/webengine_process.py
+++ b/openconnect_sso/browser/webengine_process.py
@@ -179,7 +179,7 @@ class WebBrowser(QWebEngineView):
 
 function autoFill() {{
     {get_selectors(rules, credentials)}
-    setTimeout(autoFill, 1000);
+    setTimeout(autoFill, 1588);
 }}
 autoFill();
 """
@@ -246,7 +246,8 @@ def get_selectors(rules, credentials):
             value = json.dumps(getattr(credentials, rule.fill, None))
             if value:
                 statements.append(
-                    f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.value = {value}; elem.dispatchEvent(new Event("blur")); }}"""
+                    #f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.value = {value}; elem.dispatchEvent(new Event("blur")); }}"""
+                    f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.value = {value}; elem.dispatchEvent(new Event(\'input\', {{bubbles: true}})); /*elem.dispatchEvent(new Event("blur"));*/ }}"""
                 )
             else:
                 logger.warning(
@@ -256,6 +257,7 @@ def get_selectors(rules, credentials):
                 )
         elif rule.action == "click":
             statements.append(
-                f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.click(); }}"""
+                #f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.click(); }}"""
+                f"""var elem = document.querySelector({selector}); if (elem) {{ var click_delay=728; elem.dispatchEvent(new Event("focus")); setTimeout(function() {{ document.querySelector({selector}).click(); }}, click_delay); }}"""
             )
     return "\n".join(statements)

--- a/openconnect_sso/cli.py
+++ b/openconnect_sso/cli.py
@@ -115,6 +115,12 @@ def create_argparser():
     credentials_group.add_argument(
         "-u", "--user", help="Authenticate as the given user", default=None
     )
+    credentials_group.add_argument(
+        "--passwd", help="Password to login with", default=None
+    )
+    credentials_group.add_argument(
+        "--totp", help="TOTP secret to use to login", default=None
+    )
     return parser
 
 

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,8 +106,8 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
-    _passwd = None
-    _totp = None
+    _passwd = attr.ib(default=None)
+    _totp = attr.ib(default=None)
 
     @property
     def password(self):

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,34 +106,33 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
-    _passwd = None
-    _totp = None
+    passwd = attr.ib(default=None)
+    totp = attr.ib(default=None)
 
     @property
     def password(self):
-        if self._passwd is None:
+        if self.passwd is None:
             try:
                 return keyring.get_password(APP_NAME, self.username)
             except keyring.errors.KeyringError:
                 logger.info("Cannot retrieve saved password from keyring.")
                 return ""
         else:
-            return self._passwd
+            return self.passwd
 
     @password.setter
     def password(self, value):
-        if type(value) != tuple:
+        if self.passwd is None:
             try:
                 keyring.set_password(APP_NAME, self.username, value)
             except keyring.errors.KeyringError:
                 logger.info("Cannot save password to keyring.")
         else:
-            logger.info("Unsafe pass")
-            self._passwd = value[0]
+            self.passwd = value
 
     @property
     def totp(self):
-        if self._totp is None:
+        if self.totp is None:
             try:
                 totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
                 return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
@@ -141,19 +140,17 @@ class Credentials(ConfigNode):
                 logger.info("Cannot retrieve saved totp info from keyring.")
                 return ""
         else:
-            return self._totp
+            return self.totp
 
     @totp.setter
     def totp(self, value):
-        if type(value) != tuple:
+        if self.totp is None:
             try:
                 keyring.set_password(APP_NAME, "totp/" + self.username, value)
             except keyring.errors.KeyringError:
                 logger.info("Cannot save totp secret to keyring.")
         else:
-            logger.info("Unsafe totp")
-
-            self._totp = value[0]
+            self.totp = value
 
 
 @attr.s

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,19 +106,19 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
-    __passwd__ = None
-    __totp__ = None
+    _passwd = None
+    _totp = None
 
     @property
     def password(self):
-        if self.__passwd__ is None:
+        if self._passwd is None:
             try:
                 return keyring.get_password(APP_NAME, self.username)
             except keyring.errors.KeyringError:
                 logger.info("Cannot retrieve saved password from keyring.")
                 return ""
         else:
-            return self.__passwd__
+            return self._passwd
 
     @password.setter
     def password(self, value):
@@ -128,11 +128,12 @@ class Credentials(ConfigNode):
             except keyring.errors.KeyringError:
                 logger.info("Cannot save password to keyring.")
         else:
-            self.__passwd__ = value[0]
+            logger.info("Unsafe pass")
+            self._passwd = value[0]
 
     @property
     def totp(self):
-        if self.__totp__ is None:
+        if self._totp is None:
             try:
                 totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
                 return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
@@ -140,7 +141,7 @@ class Credentials(ConfigNode):
                 logger.info("Cannot retrieve saved totp info from keyring.")
                 return ""
         else:
-            return self.__totp__
+            return self._totp
 
     @totp.setter
     def totp(self, value):
@@ -150,7 +151,9 @@ class Credentials(ConfigNode):
             except keyring.errors.KeyringError:
                 logger.info("Cannot save totp secret to keyring.")
         else:
-            self.__totp__ = value[0]
+            logger.info("Unsafe totp")
+
+            self._totp = value[0]
 
 
 @attr.s

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,8 +106,8 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
-    _passwd = attr.ib(default=None)
-    _totp = attr.ib(default=None)
+    _passwd = None
+    _totp = None
 
     @property
     def password(self):

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -126,7 +126,7 @@ class Credentials(ConfigNode):
     def totp(self):
         try:
             totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
-            return pyotp.TOTP(totpsecret).now() if totpsecret else None
+            return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
         except keyring.errors.KeyringError:
             logger.info("Cannot retrieve saved totp info from keyring.")
             return ""

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,37 +106,51 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
+    __passwd__ = None
+    __totp__ = None
 
     @property
     def password(self):
-        try:
-            return keyring.get_password(APP_NAME, self.username)
-        except keyring.errors.KeyringError:
-            logger.info("Cannot retrieve saved password from keyring.")
-            return ""
+        if self.__passwd__ is None:
+            try:
+                return keyring.get_password(APP_NAME, self.username)
+            except keyring.errors.KeyringError:
+                logger.info("Cannot retrieve saved password from keyring.")
+                return ""
+        else:
+            return self.__passwd__
 
     @password.setter
     def password(self, value):
-        try:
-            keyring.set_password(APP_NAME, self.username, value)
-        except keyring.errors.KeyringError:
-            logger.info("Cannot save password to keyring.")
+        if type(value) != tuple:
+            try:
+                keyring.set_password(APP_NAME, self.username, value)
+            except keyring.errors.KeyringError:
+                logger.info("Cannot save password to keyring.")
+        else:
+            self.__passwd__ = value[0]
 
     @property
     def totp(self):
-        try:
-            totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
-            return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
-        except keyring.errors.KeyringError:
-            logger.info("Cannot retrieve saved totp info from keyring.")
-            return ""
+        if self.__totp__ is None:
+            try:
+                totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
+                return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
+            except keyring.errors.KeyringError:
+                logger.info("Cannot retrieve saved totp info from keyring.")
+                return ""
+        else:
+            return self.__totp__
 
     @totp.setter
     def totp(self, value):
-        try:
-            keyring.set_password(APP_NAME, "totp/" + self.username, value)
-        except keyring.errors.KeyringError:
-            logger.info("Cannot save totp secret to keyring.")
+        if type(value) != tuple:
+            try:
+                keyring.set_password(APP_NAME, "totp/" + self.username, value)
+            except keyring.errors.KeyringError:
+                logger.info("Cannot save totp secret to keyring.")
+        else:
+            self.__totp__ = value[0]
 
 
 @attr.s

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -140,7 +140,7 @@ class Credentials(ConfigNode):
                 logger.info("Cannot retrieve saved totp info from keyring.")
                 return ""
         else:
-            return self._totp
+            return int(pyotp.TOTP(self._totp).now())
 
     @totp.setter
     def totp(self, value):

--- a/openconnect_sso/config.py
+++ b/openconnect_sso/config.py
@@ -106,33 +106,33 @@ def get_default_auto_fill_rules():
 @attr.s
 class Credentials(ConfigNode):
     username = attr.ib()
-    passwd = attr.ib(default=None)
-    totp = attr.ib(default=None)
+    _passwd = attr.ib(default=None)
+    _totp = attr.ib(default=None)
 
     @property
     def password(self):
-        if self.passwd is None:
+        if self._passwd is None:
             try:
                 return keyring.get_password(APP_NAME, self.username)
             except keyring.errors.KeyringError:
                 logger.info("Cannot retrieve saved password from keyring.")
                 return ""
         else:
-            return self.passwd
+            return self._passwd
 
     @password.setter
     def password(self, value):
-        if self.passwd is None:
+        if self._passwd is None:
             try:
                 keyring.set_password(APP_NAME, self.username, value)
             except keyring.errors.KeyringError:
                 logger.info("Cannot save password to keyring.")
         else:
-            self.passwd = value
+            self._passwd = value
 
     @property
     def totp(self):
-        if self.totp is None:
+        if self._totp is None:
             try:
                 totpsecret = keyring.get_password(APP_NAME, "totp/" + self.username)
                 return int(pyotp.TOTP(totpsecret).now()) if totpsecret else None
@@ -140,17 +140,17 @@ class Credentials(ConfigNode):
                 logger.info("Cannot retrieve saved totp info from keyring.")
                 return ""
         else:
-            return self.totp
+            return self._totp
 
     @totp.setter
     def totp(self, value):
-        if self.totp is None:
+        if self._totp is None:
             try:
                 keyring.set_password(APP_NAME, "totp/" + self.username, value)
             except keyring.errors.KeyringError:
                 logger.info("Cannot save totp secret to keyring.")
         else:
-            self.totp = value
+            self._totp = value
 
 
 @attr.s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.4"
+version = "0.8.5"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.7"
+version = "0.8.9"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.9"
+version = "0.8.2"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.1"
+version = "0.8.3"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
-authors = ["László Vaskó <laszlo.vasko@outlook.com>"]
+authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]
 readme = "README.md"
-homepage = "https://github.com/vlaci/openconnect-sso"
-repository = "https://github.com/vlaci/openconnect-sso"
+homepage = "https://github.com/calw20/openconnect-sso"
+repository = "https://github.com/calw20/openconnect-sso"
 
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ name = "openconnect-sso"
 version = "0.8.2"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
-authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]
+authors = ["László Vaskó <laszlo.vasko@outlook.com>"]
 readme = "README.md"
-homepage = "https://github.com/calw20/openconnect-sso"
-repository = "https://github.com/calw20/openconnect-sso"
+homepage = "https://github.com/vlaci/openconnect-sso"
+repository = "https://github.com/vlaci/openconnect-sso"
 
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.6"
+version = "0.8.7"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.3"
+version = "0.8.4"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openconnect-sso"
-version = "0.8.5"
+version = "0.8.6"
 description = "Wrapper script for OpenConnect supporting Azure AD (SAMLv2) authentication to Cisco SSL-VPNs"
 license = "GPL-3.0-only"
 authors = ["László Vaskó <laszlo.vasko@outlook.com>", "Cal W"]


### PR DESCRIPTION
This pull request does two main things:

- Adds additional delays & js update tricks to make react-based 2fa prompts (like duo) happy
- Add --passwd & --totp flags to the cli that bypass the keyring