### PR TITLE
Allow VENV_BIN to be customised

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ PRE_COMMIT_HOME=$(dir MAKEFILE_LIST).git/pre-commit
 
 ifeq ($(OS),Windows_NT)
 	PYTHON ?= python
-    VENV_BIN := .venv/Scripts
+    VENV_BIN ?= .venv/Scripts
 else
 	PYTHON ?= python3
-    VENV_BIN := .venv/bin
+    VENV_BIN ?= .venv/bin
 endif
 
 .ONESHELL:


### PR DESCRIPTION
This allows `VENV_BIN` to be overridden on the command line for those of use who would prefer not to use a virtual environment