### PR TITLE
Migrate to `importlib.resources`

### DIFF
--- a/openconnect_sso/browser/webengine_process.py
+++ b/openconnect_sso/browser/webengine_process.py
@@ -6,17 +6,21 @@ import sys
 from urllib.parse import urlparse
 
 import attr
-import pkg_resources
-import structlog
 
-from PyQt6.QtCore import QUrl, QTimer, pyqtSlot, Qt
+try:
+    import importlib.resources as importlib_resources
+except ModuleNotFoundError:
+    # Python < 3.8
+    import importlib_resources
+
+import structlog
+from PyQt6.QtCore import Qt, QTimer, QUrl, pyqtSlot
 from PyQt6.QtNetwork import QNetworkCookie, QNetworkProxy
-from PyQt6.QtWebEngineCore import QWebEngineScript, QWebEngineProfile, QWebEnginePage
+from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineProfile, QWebEngineScript
 from PyQt6.QtWebEngineWidgets import QWebEngineView
-from PyQt6.QtWidgets import QApplication, QWidget, QSizePolicy, QVBoxLayout
+from PyQt6.QtWidgets import QApplication, QSizePolicy, QVBoxLayout, QWidget
 
 from openconnect_sso import config
-
 
 app = None
 profile = None
@@ -158,7 +162,12 @@ class WebBrowser(QWebEngineView):
             return self._popupWindow.view()
 
     def authenticate_at(self, url, credentials):
-        script_source = pkg_resources.resource_string(__name__, "user.js").decode()
+        script_source = (
+            importlib_resources.files(".".join(__name__.split(".")[:-1]))
+            .joinpath("user.js")
+            .read_bytes()
+            .decode()
+        )
         script = QWebEngineScript()
         script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentCreation)
         script.setWorldId(QWebEngineScript.ScriptWorldId.ApplicationWorld)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,8 @@ openconnect-sso = "openconnect_sso.cli:main"
 python = "^3.8"
 attrs = ">=18.2"
 colorama = "^0.4"
-importlib-metadata = { version = "^3.10.0", python = "<3.8" }
-lxml = "^4.3"
-keyring = ">=21.1, <24.0.0"
+importlib-metadata = { version = "^5.1.0", python = "<3.8" }
+importlib-resources = { version = "^6.4.0", python = "<3.8" }
 prompt-toolkit = "^3.0.3"
 pyxdg = ">=0.26, <0.29"
 requests = "^2.22"


### PR DESCRIPTION
This PR updates `webengine_process` to use `importlib.resources` or `importlib_resources` over the deprecated `pkg_resources`