### PR TITLE
Update version dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ openconnect-sso = "openconnect_sso.cli:main"
 python = "^3.8"
 attrs = ">=18.2"
 colorama = "^0.4"
-importlib-metadata = { version = "^3.10.0", python = "<3.8" }
-lxml = "^4.3"
-keyring = ">=21.1, <24.0.0"
+importlib-metadata = { version = "^5.1.0", python = "<3.8" }
+importlib-resources = { version = "^6.4.0", python = "<3.8" }
+lxml = ">=4.3, <=5.1"
+keyring = ">=21.1, <25.0.0"
 prompt-toolkit = "^3.0.3"
 pyxdg = ">=0.26, <0.29"
 requests = "^2.22"
@@ -46,7 +47,7 @@ pytest-cov = "^4.0"
 pytest-httpserver = "^1.0"
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ openconnect-sso = "openconnect_sso.cli:main"
 python = "^3.8"
 attrs = ">=18.2"
 colorama = "^0.4"
-importlib-metadata = { version = "^5.1.0", python = "<3.8" }
-importlib-resources = { version = "^6.4.0", python = "<3.8" }
+importlib-metadata = { version = "^3.10.0", python = "<3.8" }
 lxml = ">=4.3, <=5.1"
 keyring = ">=21.1, <25.0.0"
 prompt-toolkit = "^3.0.3"


### PR DESCRIPTION
This PR updates the allowed versions of 
1. `lxml` up to, and including `v5.1.0`
2. `keyring` up to, but not including, `v25.0.0`