### PR TITLE
Fixing connection issue where vendor doesn't return "auth.message"

### DIFF
--- a/openconnect_sso/authenticator.py
+++ b/openconnect_sso/authenticator.py
@@ -183,9 +183,14 @@ class AuthRequestResponse:
 
 def parse_auth_complete_response(xml):
     assert xml.auth.get("id") == "success"
+    if xml.auth.banner is not None:
+        auth_message = xml.auth.banner.text
+    else:
+        auth_message = getattr(xml.auth, "message", "")
+        
     resp = AuthCompleteResponse(
         auth_id=xml.auth.get("id"),
-        auth_message=xml.auth.message,
+        auth_message=auth_message,
         session_token=xml["session-token"],
         server_cert_hash=xml.config["vpn-base-config"]["server-cert-hash"],
     )


### PR DESCRIPTION
when the auth complete response is something like this 

```
<?xml version="1.0" encoding="UTF-8"?>\n
<config-auth client="vpn" type="complete" aggregate-auth-version="2">\n
  <session-id><SESSION ID></session-id>\n
  <session-token><SESSION TOKEN></session-token>\n
  <capabilities>\n
    <crypto-supported>ssl-dhe</crypto-supported>\n
  </capabilities>\n
  <auth id="success">\n
    <banner>WARNING: This system is for the use of authorized clients only. Individuals using the computer network system without authorization, or in excess of their authorization, are subject to having all their activity on this computer network system monitored and recorded by system personnel. Access is restricted to authorized users only. Unauthorized access is a violation of state and federal, civil and criminal laws.</banner>\n
  </auth>\n
  <config client="vpn" type="private">\n
    <vpn-base-config>\n
      <nopkg></nopkg>\n
      <server-cert-hash><CERT SHA></server-cert-hash>\n
    </vpn-base-config>\n
    <opaque is-for="vpn-client">\n
      <custom-attr>\n
        <dynamic-split-include-domains>
          <![CDATA[example.com]]>
        </dynamic-split-include-domains>\n
      </custom-attr>\n
    </opaque>\n
    <vpn-profile-manifest>\n
      <vpn rev="1.0">\n
        <file type="profile" service-type="user">\n
          <uri>/CACHE/stc/profiles/profile.xml</uri>\n
          <hash type="sha1"><SHA STRING></hash>\n
        </file>\n
      </vpn>\n
    </vpn-profile-manifest>\n
  </config>\n
</config-auth>\n
```

we are getting error and openconnect-sso doesnt' work. I've made a fix to support such XML response