### PR TITLE
Send a change event that propogates to fix some login pages

### DIFF
--- a/openconnect_sso/browser/webengine_process.py
+++ b/openconnect_sso/browser/webengine_process.py
@@ -246,7 +246,7 @@ def get_selectors(rules, credentials):
             value = json.dumps(getattr(credentials, rule.fill, None))
             if value:
                 statements.append(
-                    f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.value = {value}; elem.dispatchEvent(new Event("blur")); }}"""
+                    f"""var elem = document.querySelector({selector}); if (elem) {{ elem.dispatchEvent(new Event("focus")); elem.value = {value}; elem.dispatchEvent(new Event("change", {{bubbles: true}})); elem.dispatchEvent(new Event("blur")); }}"""
                 )
             else:
                 logger.warning(


### PR DESCRIPTION
Fix for some login pages that check for a change in the text boxes. For example some Okta login pages will act as though nothing was put in the fields.